### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/set.test.ts
+++ b/src/set.test.ts
@@ -65,4 +65,12 @@ describe("Set", () => {
 
     expect(obj?.a?.b?.c).toBe("d");
   });
+
+  it("should not pollute object prototype", () => {
+    const obj = {};
+
+    set(obj, "__proto__.polluted", "yes");
+
+    expect(Object.keys(Object.prototype).includes("polluted")).toBe(false);
+  })
 });

--- a/src/set.ts
+++ b/src/set.ts
@@ -28,7 +28,7 @@ export function set(
   /* get the deepest object possible */
   while (keyIndex < keys.length) {
     const key = keys[keyIndex];
-    const value = mostNestedObj[key];
+    const value = isPrototypePolluted(key) ? {} : mostNestedObj[key];
 
     if (isObject(value)) {
       mostNestedObj = value;
@@ -58,4 +58,8 @@ export function set(
   }
 
   return obj;
+}
+
+function isPrototypePolluted(key: any) {
+  return /__proto__|constructor|prototype/.test(key);
 }


### PR DESCRIPTION
### :bar_chart: Metadata *

`object-breacher` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-breacher

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('object-breacher')

console.log(`Before: ${{}.polluted}`)
set({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i object-breacher # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105567148-428c6580-5d56-11eb-990d-d8e1ae4d3ee9.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
